### PR TITLE
Check if next level exists before debug level switch

### DIFF
--- a/core/src/main/java/core/game/entities/PlayerPawn.java
+++ b/core/src/main/java/core/game/entities/PlayerPawn.java
@@ -35,7 +35,9 @@ public class PlayerPawn extends Entity {
 
         //Debug keys- play, pain And death animations
         if (Gdx.input.isKeyJustPressed(Input.Keys.N)) {
-            GameLogic.readyChangeLevel(getNewLevelData());
+            if (GameLogic.levels.get(GameLogic.currentLevel.getLevelnumber()+1) != null) {
+                GameLogic.readyChangeLevel(getNewLevelData());
+            }
         }
 
         float checkPosX = getPos().x;


### PR DESCRIPTION
Check if next level exists before debug level switch to prevent NullPointerException.